### PR TITLE
Add and use some more `derive` classmethods

### DIFF
--- a/src/tahoe_capabilities/__init__.py
+++ b/src/tahoe_capabilities/__init__.py
@@ -52,10 +52,10 @@ from .parser import (
     capability_from_string,
     immutable_directory_from_string,
     immutable_readonly_from_string,
+    readable_from_string,
     readonly_directory_from_string,
     writeable_directory_from_string,
     writeable_from_string,
-    readable_from_string,
 )
 from .predicates import is_directory, is_mutable, is_read, is_verify, is_write
 from .serializer import danger_real_capability_string, digested_capability_string


### PR DESCRIPTION
This takes some key derivation logic out of the parser and moves it into the types, then makes use of it from the parser.  All of the capability types (for which it makes sense) should now have a `derive` method to help in their construction.